### PR TITLE
docs: Archive the repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!NOTE]
+> This repository has now been archived.
+> It was originally intended to help in triaging Dependabot PRs.
+> Please use [GitHub's documentation](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions) instead.
+
 # @guardian/automerge
 
 A simple Github App that will approve and set automerge to true on PRs raised


### PR DESCRIPTION
## What does this change?
Archiving for a couple of reasons:
  - [GitHub provide alternatives](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions)
  - The infrastructure is not used (see below)
  - The infrastructure has been manually created
  - The lambda has a public facing URL, with no authentication! 😱 This is especially scary with an unpatched library being currently used - https://github.com/guardian/automerge/security/dependabot/1.

Looking at the GitHub App, it has been installed on exactly one repository:

![image](https://github.com/guardian/automerge/assets/836140/0a83b0da-daa8-4e23-abda-6a316ea8935d)

It also doesn't seem to be working? At least https://github.com/guardian/automerge-test/pull/3 hasn't been auto-merged.

## Rollout
- [x] Merge PR
- [x] Archive repository
- [x] Teardown AWS Lambda
- [x] Remove the GitHub App
- [x] Archive https://github.com/guardian/automerge-test
